### PR TITLE
/dev/tty don't exists on windows systems

### DIFF
--- a/rlselect.py
+++ b/rlselect.py
@@ -358,8 +358,11 @@ def main():
         print(result)
         success()
 
+def platform_is_windows():
+    return sys.platform.startswith("win32")
+
 def get_ui_fn(args):
-    if args["--gui"]:
+    if platform_is_windows() or args["--gui"]:
         import wx
 
         def wx_ui_run(config, controller):


### PR DESCRIPTION
Problem: Windows users can only run in --gui mode since /dev/tty don't exists on windows system.
                The default is not to run rlselect in --gui mode, which results in exception for windows users.
Solution: Make --gui mode the only mode available for windows user without using --gui arg.